### PR TITLE
style and compilation fixes for src/uinput.c

### DIFF
--- a/src/uinput.c
+++ b/src/uinput.c
@@ -20,19 +20,19 @@ extern int motion_interval;
 
 void emit(int fd, int type, int code, int val)
 {
-   struct input_event ie;
-   memset(&ie, 0, sizeof(ie)); 
-   gettimeofday(&ie.time, NULL); 
+    struct input_event ie;
+    memset(&ie, 0, sizeof(ie));
+    gettimeofday(&ie.time, NULL);
 
-   ie.type = type;
-   ie.code = code;
-   ie.value = val;
-   /* timestamp values below are ignored */
+    ie.type = type;
+    ie.code = code;
+    ie.value = val;
+    /* timestamp values below are ignored */
 /*   ie.time.tv_sec = 0;
-   ie.time.tv_usec = 0;
+    ie.time.tv_usec = 0;
 */
-   int ret = write(fd, &ie, sizeof(ie));
-   return;
+    int ret = write(fd, &ie, sizeof(ie));
+    return;
 }
 
 
@@ -62,7 +62,7 @@ void fake_key_uinput(int fd, char *keyname, int state)
         token = strtok_r(NULL, "+", &end_token);
     }
     free(keys);
-} 
+}
 
 void fake_mouse_button_uinput(int fd, int button_number, int state)
 {
@@ -115,32 +115,32 @@ int init_uinput()
         exit(1);
     }
 
-    ioctl(fd, UI_SET_EVBIT, EV_KEY); 
+    ioctl(fd, UI_SET_EVBIT, EV_KEY);
     ioctl(fd, UI_SET_EVBIT, EV_REL);
     ioctl(fd, UI_SET_RELBIT, REL_X);
     ioctl(fd, UI_SET_RELBIT, REL_Y);
     int i;
     /* enable all keycodes support */
-    for (i=0; i < 256; i++) { 
-        ioctl(fd, UI_SET_KEYBIT, i); 
-    } 
-  
-    /* enable all mouse buttons */ 
-    ioctl(fd, UI_SET_KEYBIT, BTN_MOUSE); 
-    ioctl(fd, UI_SET_KEYBIT, BTN_TOUCH); 
-    ioctl(fd, UI_SET_KEYBIT, BTN_MOUSE); 
-    ioctl(fd, UI_SET_KEYBIT, BTN_LEFT); 
-    ioctl(fd, UI_SET_KEYBIT, BTN_MIDDLE); 
-    ioctl(fd, UI_SET_KEYBIT, BTN_RIGHT); 
-    ioctl(fd, UI_SET_KEYBIT, BTN_FORWARD); 
-    ioctl(fd, UI_SET_KEYBIT, BTN_BACK); 
-    
+    for (i=0; i < 256; i++) {
+        ioctl(fd, UI_SET_KEYBIT, i);
+    }
+
+    /* enable all mouse buttons */
+    ioctl(fd, UI_SET_KEYBIT, BTN_MOUSE);
+    ioctl(fd, UI_SET_KEYBIT, BTN_TOUCH);
+    ioctl(fd, UI_SET_KEYBIT, BTN_MOUSE);
+    ioctl(fd, UI_SET_KEYBIT, BTN_LEFT);
+    ioctl(fd, UI_SET_KEYBIT, BTN_MIDDLE);
+    ioctl(fd, UI_SET_KEYBIT, BTN_RIGHT);
+    ioctl(fd, UI_SET_KEYBIT, BTN_FORWARD);
+    ioctl(fd, UI_SET_KEYBIT, BTN_BACK);
+
     memset(&usetup, 0, sizeof(usetup));
     usetup.id.bustype = BUS_USB;
     usetup.id.vendor = 0x1234; /* sample vendor */
     usetup.id.product = 0x5678; /* sample product */
     strcpy(usetup.name, "Enjoy device");
-    
+
     ioctl(fd, UI_DEV_SETUP, &usetup);
     ioctl(fd, UI_DEV_CREATE);
     return fd;
@@ -148,6 +148,6 @@ int init_uinput()
 
 void close_uinput(int fd)
 {
-   ioctl(fd, UI_DEV_DESTROY);
-   close(fd);
+    ioctl(fd, UI_DEV_DESTROY);
+    close(fd);
 }

--- a/src/uinput.c
+++ b/src/uinput.c
@@ -17,12 +17,19 @@ extern int axis_x_direction;
 extern int axis_y_direction;
 extern int motion_interval;
 
+static void _set_input_time(struct input_event *ie)
+{
+    struct timeval time;
+    gettimeofday(&time, NULL);
+    ie->input_event_sec = time.tv_sec;
+    ie->input_event_usec = time.tv_usec;
+}
 
 void emit(int fd, int type, int code, int val)
 {
     struct input_event ie;
     memset(&ie, 0, sizeof(ie));
-    gettimeofday(&ie.time, NULL);
+    _set_input_time(&ie);
 
     ie.type = type;
     ie.code = code;


### PR DESCRIPTION
- drop trailing whitespace
- consistently use 4 spaces for indent (replace some instances where 3 spaces were used instead)
- set timestamp of `struct input_event` in a portable fashion to fix the following compilation error on (some) 32 bit systems:

```
uinput.c: In function 'emit':
uinput.c:25:20: error: 'struct input_event' has no member named 'time'
   25 |    gettimeofday(&ie.time, NULL);
      |                    ^
```